### PR TITLE
Revert "Ensure templates correctly use int, not string"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The :create action handles package installation. The internal configuration file
 * `:critical` - optional - Threshold for the default alarm criteria - Default : 95
 * `:warning` - optional - Threshold for the default alarm criteria - Default : 90
 * `:notification_plan_id` - optional - Notification plan for the alarms - Default : npTechnicalContactsEmail
-* `:variables` - optional - Additional variables you want to use in the template.`variable_name => 'value'`. It will allow to add attributes to the agent configuration if you need more than the default ones. [Here is an example](https://github.com/rackspace-cookbooks/rackspace_monitoring/blob/master/test/fixtures/cookbooks/rackspace_monitoring_check_test/recipes/http.rb#L8-L9) for `remote.http`. If you want to create your own `:template` you can use all the `:variables` with `@variable_name`. You are responsible for ensuring variables are converted from a String to an Integer, where appropriate, in your templates (e.g. send_warning, recv_warning, etc).
+* `:variables` - optional - Additional variables you want to use in the template.`variable_name => 'value'`. It will allow to add attributes to the agent configuration if you need more than the default ones. [Here is an example](https://github.com/rackspace-cookbooks/rackspace_monitoring/blob/master/test/fixtures/cookbooks/rackspace_monitoring_check_test/recipes/http.rb#L8-L9) for `remote.http`. If you want to create your own `:template` you can use all the `:variables` with `@variable_name`.
 
 ##### Used on some checks (filesystem/disk/network)
 
@@ -154,8 +154,8 @@ Then you can have your own template :
 type: remote.ping
 label: Remote ping check on <%= @target_hostname %>
 disabled: <%= @disabled %>
-period: <%= @period.to_i %>
-timeout: <%= @timeout.to_i %>
+period: <%= @period %>
+timeout: <%= @timeout %>
 target_hostname: <%= @target_hostname %>
 monitoring_zones_poll:
   - mzdfw

--- a/libraries/resource_rackspace_monitoring_check.rb
+++ b/libraries/resource_rackspace_monitoring_check.rb
@@ -13,24 +13,24 @@ class Chef
       attribute :agent_filename, kind_of: String, default: nil
       attribute :alarm, kind_of: [TrueClass, FalseClass], default: false
       attribute :alarm_criteria, kind_of: [String, Hash], default: nil
-      attribute :period, kind_of: [Fixnum, String], default: 90
-      attribute :timeout, kind_of: [Fixnum, String], default: 30
-      attribute :critical, kind_of: [Fixnum, String], default: 95
-      attribute :warning, kind_of: [Fixnum, String], default: 90
+      attribute :period, kind_of: Fixnum, default: 90
+      attribute :timeout, kind_of: Fixnum, default: 30
+      attribute :critical, kind_of: Fixnum, default: 95
+      attribute :warning, kind_of: Fixnum, default: 90
       attribute :variables, kind_of: Hash, default: {}
       attribute :notification_plan_id, kind_of: String, default: 'npTechnicalContactsEmail'
       # Required on some checks (filesystem/disk/network)
       attribute :target, kind_of: String, default: nil
       attribute :target_hostname, kind_of: String, default: nil
-      attribute :send_warning, kind_of: [Fixnum, String], default: 18_350_080
-      attribute :send_critical, kind_of: [Fixnum, String], default: 24_903_680
-      attribute :recv_warning, kind_of: [Fixnum, String], default: 18_350_080
-      attribute :recv_critical, kind_of: [Fixnum, String], default: 24_903_680
+      attribute :send_warning, kind_of: Fixnum, default: 18_350_080
+      attribute :send_critical, kind_of: Fixnum, default: 24_903_680
+      attribute :recv_warning, kind_of: Fixnum, default: 18_350_080
+      attribute :recv_critical, kind_of: Fixnum, default: 24_903_680
       # Plugins attributes
       attribute :plugin_url, kind_of: String, default: nil
       attribute :plugin_args, kind_of: Array, default: nil
       attribute :plugin_filename, kind_of: String, default: nil
-      attribute :plugin_timeout, kind_of: [Fixnum, String], default: 30
+      attribute :plugin_timeout, kind_of: Fixnum, default: 30
       # Template config
       attribute :cookbook, kind_of: String, default: 'rackspace_monitoring'
       attribute :template, kind_of: String, default: nil

--- a/templates/default/agent.cpu.conf.erb
+++ b/templates/default/agent.cpu.conf.erb
@@ -5,8 +5,8 @@
 type: agent.cpu
 label: <%= @label %>
 disabled: <%= @disabled %>
-period: <%= @period.to_i %>
-timeout: <%= @timeout.to_i %>
+period: <%= @period %>
+timeout: <%= @timeout %>
 <% if @alarm == true %>
 alarms:
     alarm-cpu:

--- a/templates/default/agent.custom.conf.erb
+++ b/templates/default/agent.custom.conf.erb
@@ -5,8 +5,8 @@
 type: <%= @type %>
 label: <%= @label %>
 disabled: <%= @disabled %>
-period: <%= @period.to_i %>
-timeout: <%= @timeout.to_i %>
+period: <%= @period %>
+timeout: <%= @timeout %>
 <% if @alarm == true %>
 alarms:
   alarm-<%= @type %>:

--- a/templates/default/agent.disk.conf.erb
+++ b/templates/default/agent.disk.conf.erb
@@ -5,8 +5,8 @@
 type: agent.disk
 label: <%= @label %>
 disabled: <%= @disabled %>
-period: <%= @period.to_i %>
-timeout: <%= @timeout.to_i %>
+period: <%= @period %>
+timeout: <%= @timeout %>
 details:
   target: <%= @target %>
 <% if @alarm == true %>

--- a/templates/default/agent.filesystem.conf.erb
+++ b/templates/default/agent.filesystem.conf.erb
@@ -5,8 +5,8 @@
 type: agent.filesystem
 label: <%= @label %>
 disabled: <%= @disabled %>
-period: <%= @period.to_i %>
-timeout: <%= @timeout.to_i %>
+period: <%= @period %>
+timeout: <%= @timeout %>
 details:
   target: <%= @target %>
 <% if @alarm == true %>

--- a/templates/default/agent.load.conf.erb
+++ b/templates/default/agent.load.conf.erb
@@ -5,8 +5,8 @@
 type: agent.load_average
 label: <%= @label %>
 disabled: <%= @disabled %>
-period: <%= @period.to_i %>
-timeout: <%= @timeout.to_i %>
+period: <%= @period %>
+timeout: <%= @timeout %>
 <% if @alarm == true %>
 alarms:
     alarm-load-average:

--- a/templates/default/agent.memory.conf.erb
+++ b/templates/default/agent.memory.conf.erb
@@ -5,8 +5,8 @@
 type: agent.memory
 label: <%= @label %>
 disabled: <%= @disabled %>
-period: <%= @period.to_i %>
-timeout: <%= @timeout.to_i %>
+period: <%= @period %>
+timeout: <%= @timeout %>
 <% if @alarm == true %>
 alarms:
     alarm-memory:

--- a/templates/default/agent.network.conf.erb
+++ b/templates/default/agent.network.conf.erb
@@ -5,8 +5,8 @@
 type: agent.network
 label: <%= @label %>
 disabled: <%= @disabled %>
-period: <%= @period.to_i %>
-timeout: <%= @timeout.to_i %>
+period: <%= @period %>
+timeout: <%= @timeout %>
 details:
   target: <%= @target %>
 <% if @alarm == true %>

--- a/templates/default/agent.plugin.conf.erb
+++ b/templates/default/agent.plugin.conf.erb
@@ -5,11 +5,11 @@
 type: agent.plugin
 label: <%= @label %>
 disabled: <%= @disabled %>
-period: <%= @period.to_i %>
-timeout: <%= @timeout.to_i %>
+period: <%= @period %>
+timeout: <%= @timeout %>
 details:
   file: <%= @plugin_filename %>
-  plugin_timeout: <%= @plugin_timeout.to_i %>
+  plugin_timeout: <%= @plugin_timeout %>
   <%- if @plugin_args %>
   args: <%= @plugin_args %>
   <%- end %>

--- a/templates/default/remote.http.conf.erb
+++ b/templates/default/remote.http.conf.erb
@@ -6,8 +6,8 @@
 type: remote.http
 label: <%= @label %>
 disabled: <%= @disabled %>
-period: <%= @period.to_i %>
-timeout: <%= @timeout.to_i %>
+period: <%= @period %>
+timeout: <%= @timeout %>
 target_hostname: <%= @target_hostname %>
 monitoring_zones_poll:
   - mzdfw

--- a/test/fixtures/cookbooks/rackspace_monitoring_check_test/templates/default/user_defined.conf.erb
+++ b/test/fixtures/cookbooks/rackspace_monitoring_check_test/templates/default/user_defined.conf.erb
@@ -6,8 +6,8 @@
 type: remote.ping
 label: Remote ping check on <%= @target_hostname %>
 disabled: <%= @disabled %>
-period: <%= @period.to_i %>
-timeout: <%= @timeout.to_i %>
+period: <%= @period %>
+timeout: <%= @timeout %>
 target_hostname: <%= @target_hostname %>
 monitoring_zones_poll:
   - mzdfw
@@ -23,7 +23,7 @@ alarms:
     label: Remote Ping check on <%= @target_hostname %>
     notification_plan_id: npTechnicalContactsEmail
     criteria: |
-      if (metric['available'] < <%= @critical.to_i %> ) {
-        return new AlarmStatus(CRITICAL, 'Ping success is bellow #{available}%, above your critical threshold of <%= @critical.to_i %>%');
+      if (metric['available'] < <%= @critical %> ) {
+        return new AlarmStatus(CRITICAL, 'Ping success is bellow #{available}%, above your critical threshold of <%= @critical %>%');
       }
 <% end %>


### PR DESCRIPTION
Reverts rackspace-cookbooks/rackspace_monitoring#13 as there was no consensus.
