### PR TITLE
fix agent.custom template yaml syntax

### DIFF
--- a/templates/default/agent.custom.conf.erb
+++ b/templates/default/agent.custom.conf.erb
@@ -11,7 +11,7 @@ timeout: <%= @timeout %>
 alarms:
   alarm-<%= @type %>:
     label: <%= @type %> Usage
-        notification_plan_id: <%= @notification_plan_id %>
-        criteria: |
+    notification_plan_id: <%= @notification_plan_id %>
+    criteria: |
 <%= @alarm_criteria %>
 <% end %>


### PR DESCRIPTION
In adding new checks, I stumbled across the 'custom' template fallback logic, which would fail on the yaml validation spec test.

This fixes the indentation issue which causes the parse error.
