### PR TITLE
add plugin_cookbook as alternate way to install agent plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ The :create action handles package installation. The internal configuration file
 * `:recv_critical` - required for network only - Threshold for the default send alarm criteria - Default : 24903680
 
 ##### Plugins attributes
-* `:plugin_url` - optional if `:plugin_filename` has been provided - Url from where to download a plugin. i.e https://raw.githubusercontent.com/racker/rackspace-monitoring-agent-plugins-contrib/master/chef_node_checkin.py
+* `:plugin_url` - optional if `:plugin_filename` has been provided, ignored if `:plugin_cookbook` is provided - Url from where to download a plugin. i.e https://raw.githubusercontent.com/racker/rackspace-monitoring-agent-plugins-contrib/master/chef_node_checkin.py
 * `:plugin_args` - optional - Arguments to pass to the plugin (Array)
 * `:plugin_filename` - optional if `:plugin_url` has been provided, mandatory otherwise.
+* `:plugin_cookbook` - optional - Cookbook to load a plugin template from. i.e wrapper or base site-cookbooks - Default : nil
 * `:plugin_timeout` - optional - The timeout for the plugin execution - Default : 30
 
 ##### Template config

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -178,6 +178,7 @@ module RackspaceMonitoringCookbook
           plugin_filename: parsed_plugin_filename,
           # Using inspect so it dumps a string representing an array
           plugin_args: new_resource.plugin_args.inspect,
+          plugin_cookbook: new_resource.plugin_cookbook,
           plugin_timeout: new_resource.plugin_timeout,
           variables: new_resource.variables
         }

--- a/libraries/provider_rackspace_monitoring_check.rb
+++ b/libraries/provider_rackspace_monitoring_check.rb
@@ -14,8 +14,8 @@ class Chef
 
       action :create do
         define_rackspace_monitoring_agent_service
-        # Download plugin if the parameter is set
-        download_plugin if new_resource.plugin_url
+        # Download plugin if either the url or cookbook parameter is set
+        download_plugin if new_resource.plugin_url || new_resource.plugin_cookbook
         generate_agent_config(false, parsed_target)
       end
 
@@ -85,10 +85,19 @@ class Chef
           action :create
           recursive true
         end
-        Chef::Log.info("Downloading plugin from #{new_resource.plugin_url} to #{plugin_path}/#{parsed_plugin_filename}")
-        remote_file "#{plugin_path}/#{parsed_plugin_filename}" do
-          mode 0755
-          source new_resource.plugin_url
+        if new_resource.plugin_cookbook
+          Chef::Log.info("Installing plugin from #{new_resource.plugin_cookbook} to #{plugin_path}/#{parsed_plugin_filename}")
+          cookbook_file "#{plugin_path}/#{parsed_plugin_filename}" do
+            cookbook new_resource.plugin_cookbook
+            mode 0755
+            source new_resource.parsed_plugin_filename
+          end
+        else
+          Chef::Log.info("Downloading plugin from #{new_resource.plugin_url} to #{plugin_path}/#{parsed_plugin_filename}")
+          remote_file "#{plugin_path}/#{parsed_plugin_filename}" do
+            mode 0755
+            source new_resource.plugin_url
+          end
         end
       end
 

--- a/libraries/resource_rackspace_monitoring_check.rb
+++ b/libraries/resource_rackspace_monitoring_check.rb
@@ -30,6 +30,7 @@ class Chef
       attribute :plugin_url, kind_of: String, default: nil
       attribute :plugin_args, kind_of: Array, default: nil
       attribute :plugin_filename, kind_of: String, default: nil
+      attribute :plugin_cookbook, kind_of: String, default: nil
       attribute :plugin_timeout, kind_of: Fixnum, default: 30
       # Template config
       attribute :cookbook, kind_of: String, default: 'rackspace_monitoring'

--- a/test/fixtures/cookbooks/rackspace_monitoring_check_test/files/default/dummy.sh
+++ b/test/fixtures/cookbooks/rackspace_monitoring_check_test/files/default/dummy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "metric ok uint32 1"
+
+exit 0
+

--- a/test/fixtures/cookbooks/rackspace_monitoring_check_test/recipes/plugin_custom.rb
+++ b/test/fixtures/cookbooks/rackspace_monitoring_check_test/recipes/plugin_custom.rb
@@ -1,0 +1,9 @@
+# comments!
+
+rackspace_monitoring_check 'agent.plugin' do
+  type 'agent.plugin'
+  plugin_cookbook 'rackspace_monitoring_check_test'
+  plugin_filename 'dummy.sh'
+  alarm true
+  action :create
+end


### PR DESCRIPTION
Consumers of this cookbook should be able to install create checks _and_ custom plugins to run those checks. Currently, the only way to make custom plugins is for the node to be online during a chef converge and be able to resolve and download an HTTP(S) resource.

This creates a dependency that isn't strictly required, as a wrapper cookbook _should be able to_ have scripts under `file/default/*` that can be referenced when creating a new check.
- [x] update docs
- [x] add integration test

fixes #17.
