### PR TITLE
Automatically create an entity for the agent if needed, no user-interaction required

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The :create action handles package installation. The internal configuration file
 * `cloud_credentials_api_key` - Your cloud [api-key](http://www.rackspace.com/knowledge_center/article/view-and-reset-your-api-key)
 * `package_name` - Rackspace monitoring agent package name (default to `rackspace-monitoring-agent`)
 * `package_action` - Which action to run when `:create` default to `install`
+* `create_entity` - Automatically create an Entity during `:create` to associate with Checks (default to `false`)
 
 #### Actions
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -233,7 +233,7 @@ module RackspaceMonitoringCookbook
 
       def target_filesystem
         target = []
-        excluded_fs = %(tmpfs devtmpfs devpts proc mqueue cgroup efivars sysfs sys securityfs configfs fusectl pstore)
+        excluded_fs = %(tmpfs devtmpfs devpts proc mqueue cgroup efivars sysfs sys securityfs configfs fusectl pstore vboxsf)
         unless node['filesystem'].nil?
           node['filesystem'].each do |key, data|
             next if data['percent_used'].nil? || data['fs_type'].nil?

--- a/libraries/provider_rackspace_monitoring_service.rb
+++ b/libraries/provider_rackspace_monitoring_service.rb
@@ -21,9 +21,11 @@ class Chef
           action new_resource.package_action
         end
 
+        auto_create_entity = new_resource.create_entity ? '--auto-create-entity' : ''
+
         # Set up rackspace-monitoring-agent
         execute 'agent-setup-cloud' do
-          command "rackspace-monitoring-agent --setup --username #{parsed_cloud_credentials_username} --apikey #{parsed_cloud_credentials_api_key}"
+          command "rackspace-monitoring-agent --setup --username #{parsed_cloud_credentials_username} --apikey #{parsed_cloud_credentials_api_key} #{auto_create_entity}"
           action 'run'
           # the filesize is zero if the agent has not been configured
           only_if { ::File.size?('/etc/rackspace-monitoring-agent.cfg').nil? }

--- a/libraries/resource_rackspace_monitoring_service.rb
+++ b/libraries/resource_rackspace_monitoring_service.rb
@@ -12,6 +12,7 @@ class Chef
       attribute :cloud_credentials_api_key, kind_of: String, default: nil
       attribute :package_action, kind_of: Symbol, default: :install
       attribute :package_name, kind_of: String, default: 'rackspace-monitoring-agent'
+      attribute :create_entity, kind_of: [TrueClass, FalseClass], default: false
     end
   end
 end

--- a/test/fixtures/cookbooks/rackspace_monitoring_service_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/rackspace_monitoring_service_test/recipes/default.rb
@@ -3,5 +3,6 @@
 rackspace_monitoring_service 'default' do
   cloud_credentials_username node['rackspace_monitoring']['cloud_credentials_username']
   cloud_credentials_api_key node['rackspace_monitoring']['cloud_credentials_api_key']
+  create_entity true
   action [:create, :start]
 end

--- a/test/unit/spec/rackspace_monitoring_check_centos65_spec.rb
+++ b/test/unit/spec/rackspace_monitoring_check_centos65_spec.rb
@@ -243,6 +243,7 @@ describe 'rackspace_monitoring_check_test::* on Centos 6.5' do
         expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.slash.yaml').with_content('target: /')
         expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.boot.yaml').with_content('target: /boot')
         expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.home.yaml').with_content('target: /home')
+        expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.vagrant.yaml').with_content("target:\n")
       end
     end
     context 'rackspace_monitoring_check with custom target' do

--- a/test/unit/spec/rackspace_monitoring_check_centos65_spec.rb
+++ b/test/unit/spec/rackspace_monitoring_check_centos65_spec.rb
@@ -243,7 +243,6 @@ describe 'rackspace_monitoring_check_test::* on Centos 6.5' do
         expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.slash.yaml').with_content('target: /')
         expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.boot.yaml').with_content('target: /boot')
         expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.home.yaml').with_content('target: /home')
-        expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.vagrant.yaml').with_content("target:\n")
       end
     end
     context 'rackspace_monitoring_check with custom target' do

--- a/test/unit/spec/rackspace_monitoring_service_shared.rb
+++ b/test/unit/spec/rackspace_monitoring_service_shared.rb
@@ -25,7 +25,7 @@ shared_examples_for 'rackspace monitoring agent set up' do |platform|
     expect(chef_run).to create_directory('/etc/rackspace-monitoring-agent.conf.d')
   end
   it 'executes rackspace-monitoring-agent setup script' do
-    expect(chef_run).to run_execute('agent-setup-cloud').with(command: 'rackspace-monitoring-agent --setup --username dummyusername --apikey dummyapikey')
+    expect(chef_run).to run_execute('agent-setup-cloud').with(command: 'rackspace-monitoring-agent --setup --username dummyusername --apikey dummyapikey --auto-create-entity')
   end
 end
 


### PR DESCRIPTION
This PR allows the cookbook to correctly run on non-cloud machines, specifically on any agent that isn't already tied to an entity.

This is done by adding the `--auto-create-entity` command-line flag that will not prompt the user if an entity doesn't exist, but should, which was added in a recent version of the (`2.x`) agent.

The command flag is not supported in early versions of 2.x or 1.x versions. We should either run an `action :upgrade` on the package or we can do an if-else check to only add the flag on supported versions.

Open question: do we want to conditionally set this? `node['rackspace_monitoring']['auto_create']`? A `auto_create` resource attribute? Both?
