### PR TITLE
Minor fix for OnMetal nodes

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -80,7 +80,7 @@ module RackspaceMonitoringCookbook
 
       def parsed_target_hostname
         return new_resource.target_hostname if new_resource.target_hostname
-        node['cloud']['public_ipv4']
+        node['cloud']['public_ipv4'] rescue node['ipaddress']
       end
 
       def parsed_target


### PR DESCRIPTION
_What_
Minor fix in libraries/helper.rb

_How_
Add a rescue statement to the parsed_target_hostname.  

_Why_
On OnMetal nodes the chef run would fail attempting to call create_rackspace_monitoring_check because there is no node.cloud.public_ipv4 variable available. 
