### PR TITLE
Install apt-transport-https on Debian systems and fix apt repo uri

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -220,6 +220,16 @@ module RackspaceMonitoringCookbook
             gpgcheck true
             action :add
           end
+        elsif node['platform'] == 'debian'
+          package 'apt-transport-https'
+
+          apt_repository 'monitoring' do
+            uri "https://stable.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['lsb']['codename']}-x86_64"
+            distribution 'cloudmonitoring'
+            components ['main']
+            key 'https://monitoring.api.rackspacecloud.com/pki/agent/linux.asc'
+            action :add
+          end
         else
           apt_repository 'monitoring' do
             uri "https://stable.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['lsb']['release']}-x86_64"


### PR DESCRIPTION
An https apt repo doesn't work on Debian Wheezy and will break apt
if one is added without the https transport being installed. Also, the
apt repo uses the codename for the debian branches rather than release
version.
