### PR TITLE
Add a check to the if logic for plugin_args.  

### DIFF
--- a/templates/default/agent.plugin.conf.erb
+++ b/templates/default/agent.plugin.conf.erb
@@ -10,8 +10,8 @@ timeout: <%= @timeout %>
 details:
   file: <%= @plugin_filename %>
   plugin_timeout: <%= @plugin_timeout %>
-  <%- if @plugin_args %>
-  args: <%= @plugin_args != 'nil' %>
+  <%- if @plugin_args != 'nil' %>
+  args: <%= @plugin_args %>
   <%- end %>
 <% if @alarm == true %>
 alarms:

--- a/templates/default/agent.plugin.conf.erb
+++ b/templates/default/agent.plugin.conf.erb
@@ -11,9 +11,8 @@ details:
   file: <%= @plugin_filename %>
   plugin_timeout: <%= @plugin_timeout %>
   <%- if @plugin_args %>
-  args: <%= @plugin_args %>
+  args: <%= @plugin_args != 'nil' %>
   <%- end %>
-
 <% if @alarm == true %>
 alarms:
   alarm-plugin:


### PR DESCRIPTION
_What_ 
Add logic to not print the args line in the YAML file if plugin_args is left at default of nil.

_How_
Update erb template to not print args line if plugin_args is nil.

_Why_
Rackspace Monitoring is expecting plugin_args to be an array.  It is listed as optional so not required.  It either needs to be there as an array or not there in the YAML file.  Setting it to nil causes an error like -

Mon Sep 14 16:29:21 2015 ERR: Confd -> config_file post operation result: failure for check at create validation, handle: {"check":"default","filename":"agent.plugin.yaml"}, error {"message":"Not an array","key":"args","parentKeys":["details"]}
