### PR TITLE
Fixing bad escapes in the agent plugin template

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -177,7 +177,7 @@ module RackspaceMonitoringCookbook
           recv_critical: parsed_recv_critical,
           plugin_filename: parsed_plugin_filename,
           # Using inspect so it dumps a string representing an array
-          plugin_args: new_resource.plugin_args.inspect,
+          plugin_args: new_resource.plugin_args ? new_resource.plugin_args.inspect : nil,
           plugin_cookbook: new_resource.plugin_cookbook,
           plugin_timeout: new_resource.plugin_timeout,
           variables: new_resource.variables

--- a/templates/default/agent.plugin.conf.erb
+++ b/templates/default/agent.plugin.conf.erb
@@ -10,9 +10,9 @@ timeout: <%= @timeout %>
 details:
   file: <%= @plugin_filename %>
   plugin_timeout: <%= @plugin_timeout %>
-  <%- if @plugin_args %>
+  <% if @plugin_args %>
   args: <%= @plugin_args %>
-  <%- end %>
+  <% end %>
 
 <% if @alarm == true %>
 alarms:

--- a/test/fixtures/cookbooks/rackspace_monitoring_check_test/recipes/plugin.rb
+++ b/test/fixtures/cookbooks/rackspace_monitoring_check_test/recipes/plugin.rb
@@ -3,7 +3,8 @@
 rackspace_monitoring_check 'agent.plugin' do
   type 'agent.plugin'
   plugin_url 'https://raw.githubusercontent.com/racker/rackspace-monitoring-agent-plugins-contrib/master/chef_node_checkin.py'
-  plugin_args ['--debug']
+  # omitted as a regression test.
+  # plugin_args nil
   plugin_filename 'awesome_plugin.py'
   alarm true
   action :create


### PR DESCRIPTION
RE: #29, it was printing `nil` because of the if statement not actually being used.
