### PR TITLE
Use new no-entity flag during set up

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,8 @@ provisioner:
   name: chef_zero
   attributes:
     rackspace_monitoring:
+      create_entity: true
+      package_channel: <%= ENV['RACKSPACE_AGENT_CHANNEL'] || 'stable' %>
       cloud_credentials_username: <%= ENV['RACKSPACE_USERNAME'] %>
       cloud_credentials_api_key: <%= ENV['RACKSPACE_API_KEY']%>
     cloud:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :lint do
 end
 
 group :unit do
-  gem 'berkshelf', '~> 3'
+  gem 'berkshelf', '~> 4.0'
   gem 'chefspec'
   gem 'chef', '= 12.0.3'
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -225,11 +225,11 @@ module RackspaceMonitoringCookbook
         end
       end
 
-      def configure_package_repositories
+      def configure_package_repositories(channel)
         if %w(rhel fedora).include? node['platform_family']
           yum_repository 'monitoring' do
             description 'Rackspace Cloud Monitoring agent repo'
-            baseurl "https://stable.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['platform_version'][0]}-x86_64"
+            baseurl "https://#{channel}.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['platform_version'][0]}-x86_64"
             gpgkey "https://monitoring.api.rackspacecloud.com/pki/agent/#{node['platform']}-#{node['platform_version'][0]}.asc"
             enabled true
             gpgcheck true
@@ -239,7 +239,7 @@ module RackspaceMonitoringCookbook
           package 'apt-transport-https'
 
           apt_repository 'monitoring' do
-            uri "https://stable.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['lsb']['codename']}-x86_64"
+            uri "https://#{channel}.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['lsb']['codename']}-x86_64"
             distribution 'cloudmonitoring'
             components ['main']
             key 'https://monitoring.api.rackspacecloud.com/pki/agent/linux.asc'
@@ -247,7 +247,7 @@ module RackspaceMonitoringCookbook
           end
         else
           apt_repository 'monitoring' do
-            uri "https://stable.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['lsb']['release']}-x86_64"
+            uri "https://#{channel}.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['lsb']['release']}-x86_64"
             distribution 'cloudmonitoring'
             components ['main']
             key 'https://monitoring.api.rackspacecloud.com/pki/agent/linux.asc'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -201,6 +201,14 @@ module RackspaceMonitoringCookbook
       def plugin_path
         '/usr/lib/rackspace-monitoring-agent/plugins'
       end
+
+      def excluded_fs
+        %(tmpfs devtmpfs devpts proc mqueue cgroup efivars sysfs sys securityfs configfs fusectl pstore vboxsf)
+      end
+
+      def disks_pattern
+        %r{^/dev/(sd|vd|xvd|hd)[a-z]}
+      end
     end
 
     # Any other helpers (mainly Chef resources)
@@ -250,7 +258,6 @@ module RackspaceMonitoringCookbook
 
       def target_filesystem
         target = []
-        excluded_fs = %(tmpfs devtmpfs devpts proc mqueue cgroup efivars sysfs sys securityfs configfs fusectl pstore vboxsf)
         unless node['filesystem'].nil?
           node['filesystem'].each do |key, data|
             next if data['percent_used'].nil? || data['fs_type'].nil?
@@ -265,7 +272,7 @@ module RackspaceMonitoringCookbook
       def target_disk
         target = []
         node['filesystem'].each do |key, data|
-          if key =~ %r{^/dev/(sd|vd|xvd|hd)[a-z]}
+          if key =~ disks_pattern
             Chef::Log.warn("Found disk : #{key}")
             target << key
           end

--- a/libraries/provider_rackspace_monitoring_service.rb
+++ b/libraries/provider_rackspace_monitoring_service.rb
@@ -14,7 +14,7 @@ class Chef
 
       action :create do
         # Yum, Apt, etc. From helpers.rb
-        configure_package_repositories
+        configure_package_repositories(new_resource.package_channel)
 
         # Software installation
         package new_resource.package_name do

--- a/libraries/provider_rackspace_monitoring_service.rb
+++ b/libraries/provider_rackspace_monitoring_service.rb
@@ -21,7 +21,7 @@ class Chef
           action new_resource.package_action
         end
 
-        auto_create_entity = new_resource.create_entity ? '--auto-create-entity' : ''
+        auto_create_entity = new_resource.create_entity ? '--auto-create-entity' : '--no-entity'
 
         # Set up rackspace-monitoring-agent
         execute 'agent-setup-cloud' do

--- a/libraries/resource_rackspace_monitoring_service.rb
+++ b/libraries/resource_rackspace_monitoring_service.rb
@@ -12,6 +12,7 @@ class Chef
       attribute :cloud_credentials_api_key, kind_of: String, default: nil
       attribute :package_action, kind_of: Symbol, default: :install
       attribute :package_name, kind_of: String, default: 'rackspace-monitoring-agent'
+      attribute :package_channel, kind_of: String, default: 'stable', regex: /^(un)?stable$/
       attribute :create_entity, kind_of: [TrueClass, FalseClass], default: false
     end
   end

--- a/test/fixtures/cookbooks/rackspace_monitoring_service_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/rackspace_monitoring_service_test/recipes/default.rb
@@ -3,6 +3,7 @@
 rackspace_monitoring_service 'default' do
   cloud_credentials_username node['rackspace_monitoring']['cloud_credentials_username']
   cloud_credentials_api_key node['rackspace_monitoring']['cloud_credentials_api_key']
-  create_entity true
+  package_channel node['rackspace_monitoring']['package_channel']
+  create_entity node['rackspace_monitoring']['create_entity']
   action [:create, :start]
 end

--- a/test/unit/spec/rackspace_monitoring_check_centos65_spec.rb
+++ b/test/unit/spec/rackspace_monitoring_check_centos65_spec.rb
@@ -240,9 +240,11 @@ describe 'rackspace_monitoring_check_test::* on Centos 6.5' do
         end.converge('rackspace_monitoring_check_test::default')
       end
       it 'creates a config for each detected target' do
-        expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.slash.yaml').with_content('target: /')
-        expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.boot.yaml').with_content('target: /boot')
-        expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.home.yaml').with_content('target: /home')
+        find_filesystems(chef_run.node) do |mount|
+          fs_name = File.basename(mount).gsub('/', 'slash')
+          config_file = "/etc/rackspace-monitoring-agent.conf.d/agent.filesystem.#{fs_name}.yaml"
+          expect(chef_run).to render_file(config_file).with_content("target: #{mount}")
+        end
       end
     end
     context 'rackspace_monitoring_check with custom target' do

--- a/test/unit/spec/rackspace_monitoring_check_ubuntu1404_spec.rb
+++ b/test/unit/spec/rackspace_monitoring_check_ubuntu1404_spec.rb
@@ -186,10 +186,16 @@ describe 'rackspace_monitoring_check_test::* on Ubuntu 14.04' do
         end.converge('rackspace_monitoring_check_test::default')
       end
       it 'creates a config for each detected target' do
-        expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.disk.vda.yaml').with_content('target: /dev/vda')
+        find_disks(chef_run.node).each do |disk|
+          config_file = "/etc/rackspace-monitoring-agent.conf.d/agent.disk.#{File.basename(disk)}.yaml"
+          expect(chef_run).to render_file(config_file).with_content("target: #{disk}")
+        end
       end
       it 'creates an alarm criteria' do
-        expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.disk.vda.yaml').with_content('An agent.disk alarm criteria')
+        find_disks(chef_run.node).each do |disk|
+          config_file = "/etc/rackspace-monitoring-agent.conf.d/agent.disk.#{File.basename(disk)}.yaml"
+          expect(chef_run).to render_file(config_file).with_content('An agent.disk alarm criteria')
+        end
       end
     end
     context 'rackspace_monitoring_check for disk with a target but without an alarm criteria' do

--- a/test/unit/spec/rackspace_monitoring_service_centos65_spec.rb
+++ b/test/unit/spec/rackspace_monitoring_service_centos65_spec.rb
@@ -39,5 +39,14 @@ describe 'rackspace_monitoring_service_test::default on Centos 6.5' do
       end
       it_behaves_like 'raise error about missing parameters'
     end
+    context 'without an entity' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(UBUNTU1204_SERVICE_OPTS) do |node|
+          node_resources(node)
+          node.set['rackspace_monitoring']['create_entity'] = false
+        end.converge('rackspace_monitoring_service_test::default')
+      end
+      it_behaves_like 'agent set up without entity'
+    end
   end
 end

--- a/test/unit/spec/rackspace_monitoring_service_shared.rb
+++ b/test/unit/spec/rackspace_monitoring_service_shared.rb
@@ -27,3 +27,10 @@ shared_examples_for 'raise error about missing parameters' do
     expect { chef_run }.to raise_error(RuntimeError)
   end
 end
+
+shared_examples_for 'agent set up without entity' do
+  it 'runs agent setup with no-entity flag' do
+    agent_command = 'rackspace-monitoring-agent --setup --username dummyusername --apikey dummyapikey --no-entity'
+    expect(chef_run).to run_execute('agent-setup-cloud').with(command: agent_command)
+  end
+end

--- a/test/unit/spec/rackspace_monitoring_service_ubuntu1204_spec.rb
+++ b/test/unit/spec/rackspace_monitoring_service_ubuntu1204_spec.rb
@@ -39,5 +39,14 @@ describe 'rackspace_monitoring_service_test::default on Ubuntu 12.04' do
       end
       it_behaves_like 'raise error about missing parameters'
     end
+    context 'without an entity' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(UBUNTU1204_SERVICE_OPTS) do |node|
+          node_resources(node)
+          node.set['rackspace_monitoring']['create_entity'] = false
+        end.converge('rackspace_monitoring_service_test::default')
+      end
+      it_behaves_like 'agent set up without entity'
+    end
   end
 end

--- a/test/unit/spec/rackspace_monitoring_service_ubuntu1404_spec.rb
+++ b/test/unit/spec/rackspace_monitoring_service_ubuntu1404_spec.rb
@@ -39,5 +39,14 @@ describe 'rackspace_monitoring_service_test::default on Ubuntu 14.04' do
       end
       it_behaves_like 'raise error about missing parameters'
     end
+    context 'without an entity' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(UBUNTU1204_SERVICE_OPTS) do |node|
+          node_resources(node)
+          node.set['rackspace_monitoring']['create_entity'] = false
+        end.converge('rackspace_monitoring_service_test::default')
+      end
+      it_behaves_like 'agent set up without entity'
+    end
   end
 end

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -2,8 +2,11 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 require_relative 'rackspace_monitoring_service_shared'
 require_relative 'rackspace_monitoring_check_shared'
+require_relative '../../../libraries/helpers'
 
 ::LOG_LEVEL = ENV['CHEFSPEC_LOG_LEVEL'] ? ENV['CHEFSPEC_LOG_LEVEL'].to_sym : :fatal
+
+CONSTS = Class.new.extend(RackspaceMonitoringCookbook::Helpers::StaticParams)
 
 def stub_resources
   allow(File).to receive(:size?).with('/etc/rackspace-monitoring-agent.cfg').and_return(nil)
@@ -13,6 +16,20 @@ def node_resources(node)
   node.set['rackspace_monitoring']['cloud_credentials_username'] = 'dummyusername'
   node.set['rackspace_monitoring']['cloud_credentials_api_key'] = 'dummyapikey'
   node.set['cloud']['local_ipv4'] = '10.0.0.1'
+end
+
+def find_disks(node)
+  node['filesystem'].keys.select { |k| k =~ CONSTS.disks_pattern }
+end
+
+def find_filesystems(node)
+  mounts = []
+  node['filesystem'].each do |k, v|
+    next if CONSTS.excluded_fs.include?(v['fs_type'])
+    mounts << v['mount']
+  end
+
+  mounts
 end
 
 at_exit { ChefSpec::Coverage.report! }

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -13,6 +13,7 @@ def stub_resources
 end
 
 def node_resources(node)
+  node.set['rackspace_monitoring']['create_entity'] = true
   node.set['rackspace_monitoring']['cloud_credentials_username'] = 'dummyusername'
   node.set['rackspace_monitoring']['cloud_credentials_api_key'] = 'dummyapikey'
   node.set['cloud']['local_ipv4'] = '10.0.0.1'


### PR DESCRIPTION
Three changes here:
1. Fixes tests that were broken by updates to Fauxhai fixture data upstream.
2. Adds a `package_channel` attribute to `rackspace_monitoring_service` to allow choosing the unstable channel. I deliberately left that out of the docs as I don't want to encourage use of unstable, but it's useful for testing the cookbook against upcoming agent releases.
3. Prevents hanging the Chef run while the agent prompts for input if `create_entity` is false on a `rackspace_monitoring_service` resource. The `--no-entity` flag was added in version [2.2.10](https://github.com/virgo-agent-toolkit/rackspace-monitoring-agent/pull/910). Older versions will ignore the flag.

You can test by setting `node['rackspace_monitoring']['create_entity']` to false in `.kitchen.yml` and running the following (until 2.2.10 is in the stable channel at least):

``` sh-session
$ kitchen create default-ubuntu-1404
$ kitchen converge default-ubuntu-1404
$ # Chef run should hang. Kill the agent process in the VM.

$ export RACKSPACE_AGENT_CHANNEL='unstable'
$ kitchen converge default-ubuntu-1404
$ # Version 2.2.10 should be installed, and no hang.
```
