### PR TITLE
Update the agent.plugin template

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The :create action handles package installation. The internal configuration file
 * `:plugin_args` - optional - Arguments to pass to the plugin (Array)
 * `:plugin_filename` - optional if `:plugin_url` has been provided, mandatory otherwise.
 * `:plugin_cookbook` - optional - Cookbook to load a plugin template from. i.e wrapper or base site-cookbooks - Default : nil
-* `:plugin_timeout` - optional - The timeout for the plugin execution - Default : 30
+* `:plugin_timeout` - optional - The timeout for the plugin execution in milliseconds - Default : 60000
 
 ##### Template config
 

--- a/libraries/resource_rackspace_monitoring_check.rb
+++ b/libraries/resource_rackspace_monitoring_check.rb
@@ -31,7 +31,7 @@ class Chef
       attribute :plugin_args, kind_of: Array, default: nil
       attribute :plugin_filename, kind_of: String, default: nil
       attribute :plugin_cookbook, kind_of: String, default: nil
-      attribute :plugin_timeout, kind_of: Fixnum, default: 30
+      attribute :plugin_timeout, kind_of: Fixnum, default: 60000 
       # Template config
       attribute :cookbook, kind_of: String, default: 'rackspace_monitoring'
       attribute :template, kind_of: String, default: nil

--- a/templates/default/agent.plugin.conf.erb
+++ b/templates/default/agent.plugin.conf.erb
@@ -9,7 +9,7 @@ period: <%= @period %>
 timeout: <%= @timeout %>
 details:
   file: <%= @plugin_filename %>
-  plugin_timeout: <%= @plugin_timeout %>
+  timeout: <%= @plugin_timeout %>
   <% if @plugin_args %>
   args: <%= @plugin_args %>
   <% end %>


### PR DESCRIPTION
Currently the agent.plugin template inserts the syntax plugin_timeout into the config file when written by chef.  I discovered it was being ignored and looked into the virgo agent code.  In the rackspace-monitoring-agent repository if you look at checks/plugin.lua you can see the code which calls for details.timeout and not details.plugin_timeout.  I did not change the usage of calling :plugin_timeout as that seems sensible within the context of the cookbook.

I updated the default value of the plugin_timeout to 60000, which matches the default value in the upstream repository.  The value is in ms.  Which is slightly confusing as the check entity timeout is in seconds, so I explicitly changed the readme to note that the plugin_timeout value is in a different unit.
