### PR TITLE
Update CHANGELOG and metadata to prep for cutting a 1.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 rackspace_monitoring CHANGELOG
 ==================
+1.1.2
+-----
+- #37 - updates to the agent.plugin template
+- #33 - Adds a package_channel attribute to rackspace_monitoring_service to allow choosing the unstable channel. I deliberately left that out of the docs as I don't want to encourage use of unstable, but it's useful for testing the cookbook against upcoming agent releases. Prevents hanging the Chef run while the agent prompts for input if create_entity is false on a rackspace_monitoring_service resource. The --no-entity flag was added in version 2.2.10. Older versions will ignore the flag.
+- #31 - update logic behind identifying best IP address
+
 1.1.1
 -----
 - #29, #30 - fix the interpretation of plugin arguments, fix template escapes

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures rackspace_monitoring'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.1'
+version '1.1.2'
 
 issues_url 'https://github.com/rackspace-cookbooks/rackspace_monitoring/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/rackspace-cookbooks/rackspace_monitoring' if respond_to?(:source_url)


### PR DESCRIPTION
Hoping we can cut a 1.1.2 release and update in the Supermarket.  Not huge changes, but I think the changes to libraries/helper.rb can help get off of a forked version I had to address an issue on OnMetal nodes.
