### PR TITLE
parsed_plugin_filename is not a method on new_resource

### DIFF
--- a/libraries/provider_rackspace_monitoring_check.rb
+++ b/libraries/provider_rackspace_monitoring_check.rb
@@ -92,7 +92,7 @@ class Chef
           cookbook_file "#{plugin_path}/#{parsed_plugin_filename}" do
             cookbook new_resource.plugin_cookbook
             mode 0o755
-            source new_resource.parsed_plugin_filename
+            source parsed_plugin_filename
           end
         else
           Chef::Log.info("Downloading plugin from #{new_resource.plugin_url} to #{plugin_path}/#{parsed_plugin_filename}")


### PR DESCRIPTION
While trying to configure a check using `plugin_filename`, I ran into the following error:

```
failed to handle resource --> :create rackspace_monitoring_check[check name]

undefined method `parsed_plugin_filename' for Chef::Resource::RackspaceMonitoringCheck
chef client failed. 0 resources updated, took 5.55 seconds
```